### PR TITLE
Fixed choosing version of recipe when several version defined for package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "aurimasniekis/flex-server",
+    "description": "A proxy-application for symfony/flex composer plugin to allow use 3rd party/private recipes",
     "require": {
         "thruster/web-application": "^0.3.1",
         "guzzlehttp/guzzle": "^6.3",

--- a/src/RecipeResolver.php
+++ b/src/RecipeResolver.php
@@ -91,7 +91,8 @@ class RecipeResolver
 
     private function getRecipe(string $vendor, string $project, string $version): array
     {
-        $versions = $this->recipes[$vendor][$project]['versions'];
+        usort($this->recipes[$vendor][$project]['versions'], 'version_compare');
+        $versions = array_reverse($this->recipes[$vendor][$project]['versions']);
 
         foreach ($versions as $availableVersion) {
             if (version_compare($version, $availableVersion, '>=')) {


### PR DESCRIPTION
This PR fixes the case when there are several version for a package and the user tries to install the latest one, server selects the first suitable starting from the lowest. This leads to incorrect recipe version selection if there is newer suitable version of the recipe.
Also this PR adds name and description fields in composer.json