### PR TITLE
Show the json error when a manifest file can't be parsed

### DIFF
--- a/src/Console/Command/BuildCacheCommand.php
+++ b/src/Console/Command/BuildCacheCommand.php
@@ -41,6 +41,12 @@ class BuildCacheCommand extends Command
 
         foreach ($finder as $fileInfo) {
             $manifest = json_decode($fileInfo->getContents(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(sprintf(
+                    'An error ocurred parsing %s: %s',
+                    realpath($fileInfo->getPathname()),
+                    json_last_error_msg()));
+            }
 
             [$vendor, $project, $version] = explode(DIRECTORY_SEPARATOR, $fileInfo->getRelativePath());
 


### PR DESCRIPTION
Thanks for this project, it's great to test out symfony flex.

I've updated the `BuildCacheCommand` to show the json error message when it fails to parse a manifest file.